### PR TITLE
Add align to ObjectMapper formatting: property <- ["key"]

### DIFF
--- a/Alignment/SourceEditorCommand.swift
+++ b/Alignment/SourceEditorCommand.swift
@@ -21,15 +21,24 @@ class SourceEditorCommand: NSObject, XCSourceEditorCommand {
         let def = UserDefaults(suiteName: "\(Bundle.main.object(forInfoDictionaryKey: "TeamIdentifierPrefix") as? String ?? "")Alignment-for-Xcode")
         let isEnableAssignment = def?.object(forKey: "KEY_ENABLE_ASSIGNMENT") as? Bool ?? true
         let isEnableTypeDeclaration = def?.object(forKey: "KEY_ENABLE_TYPE_DECLARATION") as? Bool ?? false
-
+        let isEnableTypeObjectModel = def?.object(forKey: "KEY_ENABLE_TYPE_OBJECT_MODEL") as? Bool ?? false
+        
         do {
+            
+            
             if isEnableTypeDeclaration {
-                try alignTypeDeclaration(invocation: invocation, selection: selection)
+                try align(invocation: invocation, selection: selection, key: ":")
+            }
+            
+            if isEnableTypeObjectModel {
+                try align(invocation: invocation, selection: selection, key: "<-")
             }
 
             if isEnableAssignment {
                 try alignAssignment(invocation: invocation, selection: selection)
             }
+            
+            
         } catch {
             completionHandler(NSError(domain: "SampleExtension", code: -1, userInfo: [NSLocalizedDescriptionKey: ""]))
             return
@@ -72,11 +81,12 @@ class SourceEditorCommand: NSObject, XCSourceEditorCommand {
             }
         }
     }
-
-    func alignTypeDeclaration(invocation: XCSourceEditorCommandInvocation, selection: XCSourceTextRange) throws {
+    
+    func align(invocation: XCSourceEditorCommandInvocation, selection: XCSourceTextRange, key:String) throws {
         var regex: NSRegularExpression?
-        regex = try NSRegularExpression(pattern: " *:", options: .caseInsensitive)
-
+        let key = "<-"
+        regex = try NSRegularExpression(pattern: " *\(key)", options: .caseInsensitive)
+        
         let alignPosition1 = invocation.buffer.lines.enumerated().map { i, line -> Int in
             guard i >= selection.start.line && i <= selection.end.line,
                 let line = line as? String,
@@ -85,22 +95,22 @@ class SourceEditorCommand: NSObject, XCSourceEditorCommand {
             }
             return result.range.location
             }.max()
-
+        
         for index in selection.start.line ... selection.end.line {
             guard let line = invocation.buffer.lines[index] as? NSString else {
                 continue
             }
-
-            let range = line.range(of: ":")
+            
+            let range = line.range(of: key)
             if range.location != NSNotFound {
                 let repeatCount = alignPosition1! - range.location + 1
                 if repeatCount != 0 {
                     let whiteSpaces = String(repeating: " ", count: abs(repeatCount))
-
+                    
                     if repeatCount > 0 {
-                        invocation.buffer.lines.replaceObject(at: index, with: line.replacingOccurrences(of: ":", with: "\(whiteSpaces):"))
+                        invocation.buffer.lines.replaceObject(at: index, with: line.replacingOccurrences(of: key, with: "\(whiteSpaces)\(key)"))
                     } else {
-                        invocation.buffer.lines.replaceObject(at: index, with: line.replacingOccurrences(of: "\(whiteSpaces):", with: ":"))
+                        invocation.buffer.lines.replaceObject(at: index, with: line.replacingOccurrences(of: "\(whiteSpaces)\(key)", with: key))
                     }
                 }
             }

--- a/XcodeSourceEditorExtension-Alignment/Base.lproj/Main.storyboard
+++ b/XcodeSourceEditorExtension-Alignment/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
         <capability name="system font weights other than Regular or Bold" minToolsVersion="7.0"/>
     </dependencies>
@@ -685,6 +685,17 @@
                                     <action selector="onCheckAlignTypeDeclaration:" target="XfG-lQ-9wD" id="Mql-zD-Qyu"/>
                                 </connections>
                             </button>
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rU2-TG-GAj">
+                                <rect key="frame" x="223" y="101" width="168" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="check" title="Align type ObjectModel " bezelStyle="regularSquare" imagePosition="left" inset="2" id="0QU-yf-j45">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="onCheckAlignTypeDeclaration:" target="XfG-lQ-9wD" id="xp5-eK-VXo"/>
+                                </connections>
+                            </button>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tIX-fj-dGy">
                                 <rect key="frame" x="223" y="155" width="130" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -737,7 +748,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ANn-Ws-w77">
-                                <rect key="frame" x="223" y="106" width="232" height="17"/>
+                                <rect key="frame" x="223" y="76" width="232" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Nothing happens with this setting." id="VND-Eo-cEt">
                                     <font key="font" metaFont="systemMedium" size="13"/>
@@ -753,6 +764,7 @@
                     </view>
                     <connections>
                         <outlet property="checkAlignAssignment" destination="tIX-fj-dGy" id="DLD-wl-wq2"/>
+                        <outlet property="checkAlignObjectModel" destination="rU2-TG-GAj" id="er4-i1-joS"/>
                         <outlet property="checkAlignTypeDeclaration" destination="reK-k9-VmC" id="gbz-FM-3Kt"/>
                         <outlet property="link" destination="XQz-KY-d24" id="sOp-zn-uch"/>
                         <outlet property="version" destination="rcV-h1-Zsq" id="utt-Gv-jg4"/>

--- a/XcodeSourceEditorExtension-Alignment/ViewController.swift
+++ b/XcodeSourceEditorExtension-Alignment/ViewController.swift
@@ -11,6 +11,7 @@ import Cocoa
 struct ConfigurationKey {
     static let EnableAssignment  = "KEY_ENABLE_ASSIGNMENT"
     static let EnableTypeDeclaration = "KEY_ENABLE_TYPE_DECLARATION"
+    static let EnableTypeObjectModel = "KEY_ENABLE_TYPE_OBJECT_MODEL"
 }
 
 let linkToGitHub = "https://github.com/tid-kijyun/XcodeSourceEditorExtension-Alignment"
@@ -23,6 +24,7 @@ extension NSButton {
 
 class ViewController: NSViewController {
     @IBOutlet weak var checkAlignAssignment: NSButton!
+    @IBOutlet weak var checkAlignObjectModel: NSButton!
     @IBOutlet weak var checkAlignTypeDeclaration: NSButton!
     @IBOutlet weak var warning: NSTextField!
     @IBOutlet weak var version: NSTextField! {
@@ -69,6 +71,14 @@ class ViewController: NSViewController {
             validateSettings()
         }
     }
+    
+    private var isAlignTypeObjectModel: Bool = false {
+        didSet {
+            checkAlignObjectModel.state = isAlignTypeObjectModel ? NSOnState : NSOffState
+            def?.set(isAlignTypeDeclaration, forKey: ConfigurationKey.EnableTypeObjectModel)
+            validateSettings()
+        }
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -80,10 +90,11 @@ class ViewController: NSViewController {
     func load() {
         isAlignAssignment      = def?.object(forKey: ConfigurationKey.EnableAssignment) as? Bool ?? true
         isAlignTypeDeclaration = def?.object(forKey: ConfigurationKey.EnableTypeDeclaration) as? Bool ?? false
+        isAlignTypeObjectModel = def?.object(forKey: ConfigurationKey.EnableTypeObjectModel) as? Bool ?? false
     }
 
     func validateSettings() {
-        warning.isHidden = isAlignAssignment || isAlignTypeDeclaration
+        warning.isHidden = isAlignAssignment || isAlignTypeDeclaration || isAlignTypeObjectModel
     }
 
     override var representedObject: Any? {
@@ -98,5 +109,10 @@ class ViewController: NSViewController {
     }
     @IBAction func onCheckAlignTypeDeclaration(_ sender: NSButton) {
         isAlignTypeDeclaration = sender.isChecked
+    }
+    
+    @IBAction func onCheckAlignObjectModel(_ sender: NSButton) {
+        isAlignTypeObjectModel = sender.isChecked
+        
     }
 }


### PR DESCRIPTION
Add align option to ObjectModel formatting: property <- ["key"]
https://github.com/Hearst-DD/ObjectMapper

The method now is generic, using a `key` parameter. In the feature the user can add a list of keys to align.